### PR TITLE
faet/content-delete

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,12 +1,18 @@
 import ReviewList from './ReviewList';
-import items from '../mock.json';
+import mockItems from '../mock.json';
 import { useState } from 'react';
 
 function App() {
+    const [items, setItems] = useState(mockItems);
+    
     const [order, setOrder] = useState('createdAt');
     const sortedItems = items.sort((a, b) => b[order] - a[order]);
     const handleNewestClick = () => {setOrder('createdAt')};
     const handleBestClick = () => {setOrder('rating')};
+
+    const handleDelete = (id) => {
+        const nextItems = items.filter((item) =>  item.id !== id);
+        setItems(nextItems)};
 
     return (
         <div>
@@ -14,7 +20,7 @@ function App() {
                 <button onClick={handleNewestClick}>최신순</button>
                 <button onClick={handleBestClick}>평점순</button>
             </div>    
-            <ReviewList items={sortedItems} />
+            <ReviewList items={sortedItems} onDelete={handleDelete} />
         </div>
     );
 }

--- a/src/components/ReviewList.jsx
+++ b/src/components/ReviewList.jsx
@@ -7,7 +7,9 @@ function formatDate(value) {
 }
 
 
-function ReviewListItem({ item }) {
+function ReviewListItem({ item, onDelete }) {
+    const handleDeleteClick = () => onDelete(item.id);
+    
     return (
         <div className="ReviewListItem">
             <img src={item.imgUrl} alt={item.title} className="ReviewListItem-img" />
@@ -16,19 +18,20 @@ function ReviewListItem({ item }) {
                 <p>{item.rating}</p>
                 <p>{formatDate(item.createdAt)}</p>
                 <p>{item.content}</p>
+                <button onClick={handleDeleteClick}>삭제</button>
             </div>
         </div>
     );
 }
 
 
-function ReviewList({ items }) {
+function ReviewList({ items, onDelete }) {
     return (
         <ul>
             {items.map((item) => {
                 return (
                     <li>
-                        <ReviewListItem item={item} />
+                        <ReviewListItem item={item} onDelete={onDelete} />
                     </li>
                 );
             })}


### PR DESCRIPTION
## 📌 개요 (Overview)

- 컨텐츠 삭제 기능 추가
DB는 직접 건드리지 않고 클라언트 데이터 상에서 삭제

---

## 🖼️ 시각 자료 (Screenshot or Video)

![chrome_kDEwzUHPz4](https://github.com/user-attachments/assets/55160b29-6ff8-4869-89d0-c54d7be85387)

---
