### PR TITLE
feat/file-input-initialize

### DIFF
--- a/src/components/FileInput.jsx
+++ b/src/components/FileInput.jsx
@@ -1,12 +1,27 @@
-import { useState } from "react";
+import { useRef } from "react";
 
 function FileInput({ name, value, onChange }) {
+    const inputRef = useRef();
+
     const handleChange = (e) => {
         const nextValue = e.target.files[0];
         onChange(name, nextValue);
     };
 
-    return <input type="file" onChange={handleChange} />;
+    const handleClearClick = () => {
+        const inputNode = inputRef.current;
+        if (!inputNode) return;
+
+        inputNode.value = '';
+        onChange(name, null);
+    }  
+
+    return (
+        <div>
+            <input type="file" onChange={handleChange} ref={inputRef} />
+            {value && <button onClick={handleClearClick}>X</button>}
+        </div>
+    );
 }
 
 export default FileInput;


### PR DESCRIPTION
## 📌 개요 (Overview)
<!-- 어떤 변경을 했는지 요약해 주세요 -->

- 파일업로드 form 초기화 버튼 구현

---

## ✨ 주요 변경 사항 (What’s changed?)
<!-- 어떤 파일/기능이 추가·변경되었는지 요약해주세요 -->

![chrome_HcYQ9FIaou](https://github.com/user-attachments/assets/3692c7fa-1dfc-4302-90ee-219abab543dd)

## 사용한 문법

Dom 노드를 직접 참조하는 Ref 객체를 사용함

> [!TIP] 
> cf. Ref 객체 사용 예시
```javascript
import { useRef } from 'react';

function Image({ src }) {
  const imgRef = useRef(); // ① Ref 객체 생성

  const handleSizeClick = () => {
    const imgNode = imgRef.current; // ③ Ref 객체에서 DOM 노드 참조하기
    if (!imgNode) return;

    const { width, height } = imgNode;
    console.log(`${width} x ${height}`);
  };

  return (
    <div>
      <img src={src} ref={imgRef} alt="크기를 구할 이미지" /> // ② ref Prop 사용
      <button onClick={handleSizeClick}>크기 구하기</button>
    </div>
  );
}
```



